### PR TITLE
Add simple Reverdle web game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Reverdle
+
+A simple browser-based game for reverse-engineering Wordle guesses. The page in `public/` can be deployed to any static host.
+
+## Running locally
+
+Use a static server, for example with Python:
+
+```bash
+cd public
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000` in your browser.

--- a/public/dictionary.js
+++ b/public/dictionary.js
@@ -1,0 +1,7 @@
+const DICTIONARY = [
+  'straw','feign','could','other','which','their','about','there','after','sound',
+  'great','again','still','every','large','three','right','under','world','group',
+  'start','might','house','story','night','years','since','today','heart','short',
+  'black','white','green','learn','table','print','class','music','drive','child',
+  'style','value','flash','brown','press','while','input','small','light','point'
+];

--- a/public/game.js
+++ b/public/game.js
@@ -1,0 +1,123 @@
+function createGrid(patterns) {
+  const grid = document.getElementById('grid');
+  patterns.forEach((pattern, rowIndex) => {
+    const row = document.createElement('div');
+    row.className = 'row';
+    [...pattern].forEach(ch => {
+      const cell = document.createElement('div');
+      cell.className = 'cell ' + colorClass(ch);
+      row.appendChild(cell);
+    });
+    grid.appendChild(row);
+  });
+}
+
+function colorClass(symbol) {
+  switch (symbol) {
+    case '🟩':
+      return 'green';
+    case '🟨':
+      return 'yellow';
+    default:
+      return 'black';
+  }
+}
+
+function computePattern(guess, answer) {
+  guess = guess.toLowerCase();
+  answer = answer.toLowerCase();
+  const result = Array(5).fill('⬛');
+  const answerLetters = answer.split('');
+  const used = Array(5).fill(false);
+  // Greens
+  for (let i = 0; i < 5; i++) {
+    if (guess[i] === answer[i]) {
+      result[i] = '🟩';
+      used[i] = true;
+    }
+  }
+  // Yellows
+  for (let i = 0; i < 5; i++) {
+    if (result[i] === '🟩') continue;
+    const idx = answerLetters.findIndex((ch, j) => !used[j] && ch === guess[i]);
+    if (idx !== -1) {
+      result[i] = '🟨';
+      used[idx] = true;
+    }
+  }
+  return result.join('');
+}
+
+let currentRow = 0;
+let attempts = 6;
+
+function setupGame() {
+  createGrid(PUZZLE.patterns);
+  showInput();
+}
+
+function showInput() {
+  const area = document.getElementById('input-area');
+  area.innerHTML = '';
+  if (currentRow >= PUZZLE.patterns.length) {
+    document.getElementById('message').textContent = 'You solved them all!';
+    return;
+  }
+  const rowDiv = document.createElement('div');
+  rowDiv.className = 'guess-row';
+  const input = document.createElement('input');
+  input.maxLength = 5;
+  input.autofocus = true;
+  const btn = document.createElement('button');
+  btn.textContent = 'Guess';
+  btn.onclick = () => handleGuess(input.value);
+  rowDiv.appendChild(input);
+  rowDiv.appendChild(btn);
+  area.appendChild(rowDiv);
+  document.getElementById('message').textContent = `Row ${currentRow+1}, attempts left: ${attempts}`;
+}
+
+function handleGuess(value) {
+  const guess = value.trim().toLowerCase();
+  if (guess.length !== 5) {
+    alert('Guess must be 5 letters');
+    return;
+  }
+  if (!DICTIONARY.includes(guess)) {
+    alert('Word not in dictionary');
+    return;
+  }
+  const pattern = computePattern(guess, PUZZLE.answer);
+  const guessRow = document.createElement('div');
+  guessRow.className = 'row';
+  [...pattern].forEach(ch => {
+    const cell = document.createElement('div');
+    cell.className = 'cell ' + colorClass(ch);
+    cell.textContent = ch;
+    guessRow.appendChild(cell);
+  });
+  document.getElementById('grid').appendChild(guessRow);
+  attempts--;
+  if (pattern === PUZZLE.patterns[currentRow]) {
+    currentRow++;
+    attempts = 6;
+    showInput();
+  } else if (attempts === 0) {
+    gameOver();
+  } else {
+    document.getElementById('message').textContent = `Row ${currentRow+1}, attempts left: ${attempts}`;
+  }
+}
+
+function gameOver() {
+  const area = document.getElementById('input-area');
+  area.innerHTML = '';
+  let msg = 'Game over! Solutions:\n';
+  PUZZLE.solutions.forEach((w, i) => {
+    msg += `${i+1}. ${w}\n`;
+  });
+  alert(msg);
+  document.getElementById('message').textContent = 'Game over';
+}
+
+document.addEventListener('DOMContentLoaded', setupGame);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reverdle</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <h1>Reverdle</h1>
+    <div id="grid" class="grid"></div>
+    <div id="input-area"></div>
+    <div id="message"></div>
+    <script src="dictionary.js"></script>
+    <script src="puzzle.js"></script>
+    <script src="game.js"></script>
+</body>
+</html>

--- a/public/puzzle.js
+++ b/public/puzzle.js
@@ -1,0 +1,9 @@
+const PUZZLE = {
+  answer: 'oddly',
+  patterns: [
+    '⬛⬛⬛⬛⬛',
+    '⬛⬛⬛⬛⬛',
+    '⬛🟨⬛🟩🟨'
+  ],
+  solutions: ['straw','feign','could']
+};

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,12 @@
+body { font-family: sans-serif; text-align: center; margin: 0; padding: 0; }
+h1 { background: #333; color: white; margin: 0; padding: 1em 0; }
+.grid { display: inline-block; margin: 1em auto; }
+.row { display: flex; justify-content: center; margin-bottom: 4px; }
+.cell { width: 40px; height: 40px; border: 1px solid #999; display: inline-flex; align-items: center; justify-content: center; font-weight: bold; text-transform: uppercase; }
+.black { background: #121213; color: white; }
+.yellow { background: #c9b458; color: white; }
+.green { background: #6aaa64; color: white; }
+.guess-row { margin-top: 0.5em; }
+#input-area input { width: 120px; padding: 0.5em; text-transform: uppercase; }
+#input-area button { padding: 0.5em; margin-left: 4px; }
+#message { margin-top: 1em; font-weight: bold; }


### PR DESCRIPTION
## Summary
- add a static Reverdle implementation in `public`
- include a small word dictionary and sample puzzle
- basic JS game logic and styling
- document how to run locally

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68598e30738c832fa631e04c6f19243f